### PR TITLE
Move link args to end of the command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 
 all:
-	g++  -std=c++14 -ludev -lpthread -I source source/*.cpp source/*/*.cpp source/*/*/*.cpp -o moltengamepad
+	g++ -std=c++14 -I source source/*.cpp source/*/*.cpp source/*/*/*.cpp -o moltengamepad -ludev -lpthread
 
 clean:
 	rm ./moltengamepad
 debug:
-	g++ -g -std=c++14 -ludev -lpthread -I source source/*.cpp source/*/*.cpp source/*/*/*.cpp -o moltengamepad
+	g++ -g -std=c++14 -I source source/*.cpp source/*/*.cpp source/*/*/*.cpp -o moltengamepad -ludev -lpthread
 
 steam:
-	g++  -DBUILD_STEAM_CONTROLLER_DRIVER -std=c++14 -lscraw -ludev -lpthread -I source source/*.cpp source/*/*.cpp source/*/*/*.cpp -o moltengamepad
+	g++ -DBUILD_STEAM_CONTROLLER_DRIVER -std=c++14 -lscraw -I source source/*.cpp source/*/*.cpp source/*/*/*.cpp -o moltengamepad -ludev -lpthread


### PR DESCRIPTION
Fixes #4 on Xubuntu 15.10.