### PR TITLE
Better permission blocking for udev

### DIFF
--- a/installation/systemuser/install.sh
+++ b/installation/systemuser/install.sh
@@ -10,14 +10,15 @@ useradd -r -U gamepad
 # Install the files contained in the repo.
 cd "$(dirname "$0")"
 install -Dm0644 profile-sdl2.sh /etc/profile.d/sdl2-gamecontroller-moltengamepad.sh
-install -Dm0644 systemd.service /etc/systemd/system/moltengamepad.service 
+install -Dm0644 systemd.service /etc/systemd/system/moltengamepad.service
 install -Dm0644 tmpfiles.conf /etc/tmpfiles.d/moltengamepad.conf
-install -Dm0644 udev.rules /etc/udev/rules.d/90-moltengamepad.rules
+install -Dm0644 udev.rules /etc/udev/rules.d/72-moltengamepad.rules
 
 # Reload the various services we have affected.
 udevadm control --reload
 systemd-tmpfiles --create
 systemctl daemon-reload
+
 # Reload uinput to get its new permissions.
 rmmod uinput
 modprobe uinput

--- a/installation/systemuser/udev.rules
+++ b/installation/systemuser/udev.rules
@@ -1,5 +1,5 @@
 # udev rules for system-wide MoltenGamepad.
-# Installs as 90-moltengamepad.rules.
+# Installs as 72-moltengamepad.rules.
 
 # Allow gamepad user access to uinput.
 KERNEL=="uinput" RUN+="/usr/bin/setfacl -m gamepad:rw- %E{DEVNAME}"
@@ -12,7 +12,7 @@ SUBSYSTEM=="input", ACTION=="add", ATTRS{phys}=="moltengamepad*", \
 SUBSYSTEM=="input", ACTION=="add", \
  ENV{ID_INPUT_JOYSTICK}=="?*", ATTRS{phys}!="moltengamepad*", \
  OWNER:="gamepad", GROUP:="gamepad", MODE:="0600", \
- RUN+="/usr/bin/setfacl -m mask:--- %E{DEVNAME}"
+ TAG-="uaccess", TAG-="seat"
 
 # Wiimote rules, as they do not match ID_INPUT_JOYSTICK.
 SUBSYSTEM=="leds", ACTION=="add", DRIVERS=="wiimote", \
@@ -21,4 +21,4 @@ SUBSYSTEM=="leds", ACTION=="add", DRIVERS=="wiimote", \
 
 SUBSYSTEM=="input", DRIVERS=="wiimote", MODE="0666", \
  OWNER:="gamepad", GROUP:="gamepad", MODE:="0600", \
- RUN+="/usr/bin/setfacl -m mask:--- %E{DEVNAME}"
+ TAG-="uaccess", TAG-="seat"


### PR DESCRIPTION
So I'm a weird dude who runs his games in a separate X server, and doing that causes weird behavior to manifest, such as the fact that somehow permissions on devices gets re-mutated. It seems like udev selectively runs through some of the rules whenever an X server gets started. I thought using setfacl to change the mask would stop the permissions from getting changed, but it seems not. I know that the uaccess and seat tags have something to do with it, so what I do now is strip those tags immediately after they are given. Because of this, the udev rules have to be moved to order 72 rather than 90, as uaccess and seat are 70 and 71 respectively. Whatever rules mutate the access lists according to the tags comes sometime after that. I can't tell what does it. With this in place, mutating the access list mask isn't necessary since it just doesn't get touched at all without those tags active. It works perfectly well on Xubuntu 16.04. Can you try it out on Arch?
