### PR TITLE
Online calibration feature implemented

### DIFF
--- a/documentation/calibratable.md
+++ b/documentation/calibratable.md
@@ -1,0 +1,54 @@
+
+Now we have a group that allow "hot calibration or online calibration". Yes, you can calibrate your gamepad while you are plugin.
+
+I design this group thinking in using the wiimote like lightgun for MAME or nestopia. The syntax is the following:
+
+```
+<gamepad>.(<key,<axes>,<key>) = calibratable(<axes_code>)
+```
+
+We are going to put an example to understand this:
+
+```
+wiimote.(wm_home,wm_ir_x,wm_b) = calibratable(abs_x)
+```
+
+We want to calibrate wiimote infrared x axes. And this will be mapped to abs_x of our gamepad.
+ - The first key event triggers the calibration. After we press wm_home we start to calibrate.
+ - The second is the input we want to calibrate.
+ - The third is key event that we use to recolect data to calibrate. In other words, if we press wm_b we save the data value of wiimote to use it to calibration process.
+
+Now we are going to explain the process to calibrate with this configuration. We are calibrating inside the game and we have some croshair or some feedback of the game to know where we are shooting. 
+We suppose we want to use the wiimote like light gun so we have something like this configuration in profile:
+
+```
+wiimote.(wm_home,wm_ir_x,wm_b) = calibratable(abs_x)
+wiimote.(wm_home,wm_ir_y,wm_b) = calibratable(abs_y)
+```
+Yes, we use the same keys for events, so we can calibrate axes *x* and *y* at once. The process is:
+ 1. We press *wm_home*.
+ 2. We aim with the wiimote to the left up corner of the game screen and then we press *wm_b* (shot), not the physical screen. Not alwayes are the same, we can have black bars on the sides.
+ 3. No we point with the crosshair of the game to the left up corner of the game screen adn press *wm_b*(shot). Remember you put at the corner the feedback information for shot positions.
+ 4. We aim with the wiimote to the right down corner of the game screen and then we press *wm_b* (shot).
+ 5. No we point with the crosshair of the game to the right down corner of the game screen adn press *wm_b*(shot). 
+ 6. Now you can play aiming with the gun not with crosshair of the game.
+
+Usually with one calibratio all is perfect, but sometimes we need to calibrate again to have a more accurate calibration. At this situation we can use other calibration mode: the *compose calibration mode*.
+
+We have two modes of calibration:
+    1. Before start the calibration, we reset calibration data.
+    2. We compose the new calibration data with the old.
+
+If you only press *wm_home* you are using the mode *1*. When you start the calibration, the current calibration data are reset and you restart the calibration.
+If your press *wm_b* and after *wm_home* keeping pressed *wm_b*. Now you start calibration process, keeping the old data calibration. The result is a composition of the two calibration. This mode is good for fine tune calibration.
+
+I have explained this for lightgun, but could be use with whatever analog controls you want to use. And you can configure whatever keys or axes you want.
+
+Have a good time with your wiimote light gun!!!
+
+
+
+
+
+
+

--- a/documentation/calibratable.md
+++ b/documentation/calibratable.md
@@ -1,7 +1,7 @@
 
-Now we have a group that allow "hot calibration or online calibration". Yes, you can calibrate your gamepad while you are plugin.
+Now we have a group that allow "hot calibration or online calibration". Yes, you can calibrate your gamepad while you are playing.
 
-I design this group thinking in using the wiimote like lightgun for MAME or nestopia. The syntax is the following:
+I design this group thinking in using the wiimote like light gun in MAME or nestopia. The syntax is the following:
 
 ```
 <gamepad>.(<key,<axes>,<key>) = calibratable(<axes_code>)
@@ -14,41 +14,38 @@ wiimote.(wm_home,wm_ir_x,wm_b) = calibratable(abs_x)
 ```
 
 We want to calibrate wiimote infrared x axes. And this will be mapped to abs_x of our gamepad.
- - The first key event triggers the calibration. After we press wm_home we start to calibrate.
+ - The first key event triggers the calibration. After we press _wm_home_ we start to calibrate.
  - The second is the input we want to calibrate.
- - The third is key event that we use to recolect data to calibrate. In other words, if we press wm_b we save the data value of wiimote to use it to calibration process.
+ - The third is key event that we use to recolect data to calibrate. In other words, if we press _wm_b_ we save the data value of wiimote to use it to calibration process.
 
-Now we are going to explain the process to calibrate with this configuration. We are calibrating inside the game and we have some croshair or some feedback of the game to know where we are shooting. 
-We suppose we want to use the wiimote like light gun so we have something like this configuration in profile:
+Now we are going to explain the process to calibrate with this configuration. The idea is to calibrate while we are playing a game. The game should have a crosshair or some feedback to know where we are shooting. 
+I suppose we want to use the wiimote like light gun so we have something like this configuration in profile:
 
 ```
 wiimote.(wm_home,wm_ir_x,wm_b) = calibratable(abs_x)
 wiimote.(wm_home,wm_ir_y,wm_b) = calibratable(abs_y)
 ```
-Yes, we use the same keys for events, so we can calibrate axes *x* and *y* at once. The process is:
- 1. We press *wm_home*.
- 2. We aim with the wiimote to the left up corner of the game screen and then we press *wm_b* (shot), not the physical screen. Not alwayes are the same, we can have black bars on the sides.
- 3. No we point with the crosshair of the game to the left up corner of the game screen adn press *wm_b*(shot). Remember you put at the corner the feedback information for shot positions.
- 4. We aim with the wiimote to the right down corner of the game screen and then we press *wm_b* (shot).
- 5. No we point with the crosshair of the game to the right down corner of the game screen adn press *wm_b*(shot). 
- 6. Now you can play aiming with the gun not with crosshair of the game.
 
-Usually with one calibratio all is perfect, but sometimes we need to calibrate again to have a more accurate calibration. At this situation we can use other calibration mode: the *compose calibration mode*.
+Yes, we use the same keys for events, so we can calibrate axes *x* and *y* at once. The process is:
+
+ 1. We press *wm_home*.
+ 2. We aim with the wiimote to the left up corner of the game screen and then we press *wm_b* (shot), not the physical screen. Not always are the same, we can have black bars on the sides because of aspect ratio.
+ 3. Now we point with the crosshair of the game to the left up corner of the game screen and press *wm_b*(shot). Remember you put at the corner the feedback information for shot positions.
+ 4. We aim with the wiimote to the right down corner of the game screen and then we press *wm_b* (shot).
+ 5. After we point with the crosshair of the game to the right down corner of the game screen adn press *wm_b*(shot). 
+ 6. Now you can play aiming with the gun without need the crosshair of the game.
+
+Usually with one calibration all is working perfect, but sometimes we need to calibrate again to have a more accurate calibration. At this situation we can use other calibration mode: the *compose calibration mode*.
 
 We have two modes of calibration:
-    1. Before start the calibration, we reset calibration data.
-    2. We compose the new calibration data with the old.
+
+  1. Before start the calibration, we **reset** calibration data.
+  2. We **compose** the new calibration data with the old.
 
 If you only press *wm_home* you are using the mode *1*. When you start the calibration, the current calibration data are reset and you restart the calibration.
-If your press *wm_b* and after *wm_home* keeping pressed *wm_b*. Now you start calibration process, keeping the old data calibration. The result is a composition of the two calibration. This mode is good for fine tune calibration.
+
+If you press *wm_b* and after *wm_home* (keeping pressed *wm_b*). Now you start calibration process, keeping the old data calibration. The result is a composition of the two calibration. This mode is good for fine tune calibration.
 
 I have explained this for lightgun, but could be use with whatever analog controls you want to use. And you can configure whatever keys or axes you want.
 
 Have a good time with your wiimote light gun!!!
-
-
-
-
-
-
-

--- a/source/core/event_translators/group/calibratable.cpp
+++ b/source/core/event_translators/group/calibratable.cpp
@@ -1,0 +1,79 @@
+#include "calibratable.h"
+#include "../event_translator_macros.h"
+#include <cmath>
+
+typedef enum {
+    ID_EVENT_RECALIBRATE,
+    ID_EVENT_AXIS,
+    ID_EVENT_SET,
+}IDEventCalibratable;
+
+const char* calibratable::decl = "key, axis, key = calibratable(axis_code a)";
+calibratable::calibratable(std::vector<MGField>& fields) {
+  BEGIN_READ_DEF;
+  READ_AXIS(axis);
+}
+
+bool calibratable::set_mapped_events(const std::vector<source_event>& listened) {
+  if (listened.size() != 3) {
+      return false;
+  }
+  cached_input_axes = listened[ID_EVENT_AXIS].value;
+  cached_input_set = listened[ID_EVENT_SET].value;
+  return true;
+
+}
+  
+void calibratable::fill_def(MGTransDef& def) {
+  BEGIN_FILL_DEF("calibratable");
+  FILL_DEF_AXIS(axis);
+}
+
+void calibratable::init(input_source* source) {
+  this->owner = source;
+};
+
+void calibratable::attach(input_source* source) {
+  this->owner = source;
+};
+
+
+
+bool calibratable::claim_event(int id, mg_ev event) {
+    switch (id){
+        case ID_EVENT_RECALIBRATE:
+            if(event.value == 1){
+                // if not pressed reset calibration
+                calibration->start_calibration(cached_input_set == 0);
+            }
+            break;
+        case ID_EVENT_SET:
+            cached_input_set = event.value;
+            if(cached_input_set == 1  && calibration ->is_calibrating()){
+               calibration->save_calibrate_data(cached_input_axes); 
+            }
+            break;
+        case ID_EVENT_AXIS:
+            cached_input_axes = event.value;
+            break;
+        default:
+            //TODO: notify error
+            break;
+    }
+    return false;
+};
+
+void calibratable::process_syn_report(virtual_device* out){
+    struct input_event out_ev;
+    output_event_val = calibration->get_game_value(cached_input_axes);
+    if (cached_output_event_val == output_event_val){
+        return;
+    }
+    cached_output_event_val = output_event_val;
+    memset(&out_ev, 0, sizeof(out_ev));
+    out_ev.type = EV_ABS;
+    out_ev.code = axis;
+    out_ev.value = output_event_val;
+    out->take_event(out_ev);
+}
+		

--- a/source/core/event_translators/group/calibratable.h
+++ b/source/core/event_translators/group/calibratable.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "../event_change.h"
+#include "calibration.h"
+
+class calibratable : public group_translator {
+public:
+  int64_t cached_input_set;
+  int64_t cached_input_axes;
+  int64_t output_event_val;
+  int64_t cached_output_event_val;
+  int recalibrate_event; // event that help us to take the photo of the axis
+  int axis;
+  int set_event;
+  input_source* owner = nullptr;
+
+  //setting field_flags is optional, but this surpresses printing out those default values later.
+  //note that this constructor is only called in hard-coded situations, not during parsing.
+  calibratable(int axis) :axis(axis) {
+    field_flags.push_back(0); //axis
+    calibration = std::make_shared<LinearCalibration>();
+  };
+
+  virtual ~calibratable(){
+        calibration = nullptr;
+  }
+  virtual bool clear_other_translations() { return false; };
+  virtual void process_syn_report(virtual_device* out);
+
+  virtual void init(input_source* source);
+  virtual void attach(input_source* source);
+  virtual bool set_mapped_events(const std::vector<source_event>& listened);
+
+  virtual bool claim_event(int id, mg_ev event);
+
+  virtual group_translator* clone() {
+      calibratable * cloned = new calibratable(axis);
+      if(calibration){
+          cloned->calibration =  calibration->clone();
+      }
+      return cloned;
+  }
+
+  static const char* decl;
+  calibratable(std::vector<MGField>& fields);
+  virtual void fill_def(MGTransDef& def);
+protected:
+  std::shared_ptr<Calibration> calibration = nullptr;
+};

--- a/source/core/event_translators/group/calibratable.h
+++ b/source/core/event_translators/group/calibratable.h
@@ -12,10 +12,9 @@ public:
   int axis;
   int set_event;
   input_source* owner = nullptr;
-
   //setting field_flags is optional, but this surpresses printing out those default values later.
   //note that this constructor is only called in hard-coded situations, not during parsing.
-  calibratable(int axis) :axis(axis) {
+  calibratable(int axis) :axis(axis), is_calibrating(false) {
     field_flags.push_back(0); //axis
     calibration = std::make_shared<LinearCalibration>();
   };
@@ -45,4 +44,8 @@ public:
   virtual void fill_def(MGTransDef& def);
 protected:
   std::shared_ptr<Calibration> calibration = nullptr;
+  std::vector<int64_t> input_samples;
+  int number_samples;
+  int index_sample;
+  bool is_calibrating;
 };

--- a/source/core/event_translators/group/calibration.h
+++ b/source/core/event_translators/group/calibration.h
@@ -2,14 +2,20 @@
 
 class Calibration{
     public:
-        // Start calibration machine state 
-        virtual void start_calibration(bool reset_calibration) = 0;
-        // Save data for calibrate adn return true when calibration proccess finish
-        // If we need more data returns false
-        virtual bool save_calibrate_data(int64_t value) = 0;
+        virtual int get_number_samples_needed_to_calibrate() = 0; 
+        // Get a string to show information about the sample input.
+        virtual std::string get_feedback_msg(int index) = 0;
+
+        // Reset calibration, now the class returns raw input.
+        virtual void reset_calibration() = 0;
+        // Readjust the calibration
+        virtual void calibrate(const std::vector<int64_t>& input_samples) = 0;
+
         // Aply the transformation from user_value to game value
         virtual int64_t get_game_value(int64_t user_value) = 0;
-        virtual bool is_calibrating() = 0;
+
+
+
         virtual std::shared_ptr<Calibration> clone() = 0;
         virtual ~Calibration(){};
 };
@@ -17,100 +23,77 @@ class Calibration{
 // Implements linear calibration: game_values = a * user_value + b
 // 
 class LinearCalibration : public Calibration {
-    typedef enum {
-        CALIBRATE_SLEEP,
-        CALIBRATE_WAITING_MY_INPUT_0,
-        CALIBRATE_WAITING_GAME_INPUT_0,
-        CALIBRATE_WAITING_MY_INPUT_1,
-        CALIBRATE_WAITING_GAME_INPUT_1,
-    }StatusCalibration;
     public:
-    LinearCalibration(): a(1.0), b(0.0),status_calibration(CALIBRATE_SLEEP) {};
-    LinearCalibration(float a, float b): a(a), b(b), status_calibration(CALIBRATE_SLEEP){};
-    virtual ~LinearCalibration(){};
-    void start_calibration(bool reset_calibration) {
-        status_calibration = CALIBRATE_WAITING_MY_INPUT_0;
-        // reset the last calibration
-        if(reset_calibration){
+        LinearCalibration(): a(1.0), b(0.0){};
+        LinearCalibration(float a, float b): a(a), b(b){};
+
+        virtual ~LinearCalibration(){};
+
+        virtual int get_number_samples_needed_to_calibrate(){
+            return 4;
+        } 
+
+        virtual std::string get_feedback_msg(int index){
+            switch(index){
+                case 0:
+                    return "Taking max value of your controller";
+                case 1:
+                    return "Taking max value in game";
+                case 2:
+                    return "Taking min value of your controller";
+                case 3:
+                    return "Taking min value in game";
+                default:
+                    break;
+            }
+            return "ERROR: bad value of index. We only take 4 samples.";
+
+        }
+        virtual void reset_calibration(){
             a = 1.0;
             b = 0.0;
         }
-        std::cout << "Start Linear Calibration: " 
-            << (reset_calibration ? "reset": "composing with last calibration") << std::endl;
-    };
-    // Save data for calibrate and return true when calibration proccess finish
-    // If we need more data returns false
-    virtual bool save_calibrate_data(int64_t value){
-        switch(status_calibration){
-            case CALIBRATE_WAITING_MY_INPUT_0:
-                user_values[0] = get_game_value(value);
-                status_calibration = CALIBRATE_WAITING_GAME_INPUT_0;
-                break;
-            case CALIBRATE_WAITING_GAME_INPUT_0:
-                // now calibrate
-                game_values[0] = get_game_value(value);
-                status_calibration = CALIBRATE_WAITING_MY_INPUT_1;
-                break;
-            case CALIBRATE_WAITING_MY_INPUT_1:
-                user_values[1] = get_game_value(value);
-                //TODO save my_value;
-                status_calibration = CALIBRATE_WAITING_GAME_INPUT_1;
-                break;
-            case CALIBRATE_WAITING_GAME_INPUT_1:
-                // now calibrate
-                game_values[1] = get_game_value(value);
-                calibrate();
-                status_calibration = CALIBRATE_SLEEP;
-                return false;
-                break;
-            default:
-                std::cout << __PRETTY_FUNCTION__ 
-                    <<"ERROR: unspected state. Stopping calibration " << status_calibration 
-                    << std::endl;
-                status_calibration = CALIBRATE_SLEEP;
+        virtual void calibrate(const std::vector<int64_t>& input_samples){
+            int64_t user_values [2] = {get_game_value(input_samples[0]), get_game_value(input_samples[2])};
+            int64_t game_values [2] = {input_samples[1], input_samples[3]};
+            
+            // We have to resolve this system of ecuations
+            // game_values[0] = a * user_values[0] + b;
+            // game_values[1] = a * user_values[1] + b;
+
+            float tmp_a = ((float) (game_values[0] - game_values[1])) / ( (float) (user_values[0] -  user_values[1]));
+            float tmp_b = ((float) (user_values[0]*game_values[1] - game_values[0]*user_values[1])) / ((float)(user_values[0] - user_values[1]));
+            // Now we adjust to compose with last calibration.
+            a = tmp_a * a;
+            b = tmp_a*b + tmp_b;
+            std::cout << "Calibration Success. Values are: " 
+                //            << " user0: " << user_values[0]
+                //            << " user1: " << user_values[1]
+                //            << " game0: " << game_values[0]
+                //            << " game1: " << game_values[1]
+                << " a: " << a
+                << " b: " << b
+                << std::endl;
+
         }
-        return true;
-    }
-    // Aply the transformation from user_value to game value
-    virtual int64_t get_game_value(int64_t user_value){
-        int64_t result = (user_value * a) + b;
-        // check saturation
-        if(result > ABS_RANGE){
-            result = ABS_RANGE;
-        }else if (result < -ABS_RANGE){
-            result = -ABS_RANGE;
+
+
+        // Aply the transformation from user_value to game value
+        virtual int64_t get_game_value(int64_t user_value){
+            int64_t result = (user_value * a) + b;
+            // check saturation
+            if(result > ABS_RANGE){
+                result = ABS_RANGE;
+            }else if (result < -ABS_RANGE){
+                result = -ABS_RANGE;
+            }
+            return result;
         }
-        return result;
-    }
-    virtual bool is_calibrating(){
-        return status_calibration != CALIBRATE_SLEEP;
-    }
+        virtual std::shared_ptr<Calibration> clone(){
+            return  std::make_shared<LinearCalibration>(a, b);
+        }
 
     protected:
-    float a;
-    float b;
-    int64_t game_values [2];
-    int64_t user_values [2];
-    StatusCalibration status_calibration;
-    void calibrate(){
-        // We have to resolve this system of ecuations
-        // game_values[0] = a * user_values[0] + b;
-        // game_values[1] = a * user_values[1] + b;
-        float tmp_a = ((float) (game_values[0] - game_values[1])) / ( (float) (user_values[0] -  user_values[1]));
-        float tmp_b = ((float) (user_values[0]*game_values[1] - game_values[0]*user_values[1])) / ((float)(user_values[0] - user_values[1]));
-        // Now we adjust to compose with last calibration.
-        a = tmp_a * a;
-        b = tmp_a*b + tmp_b;
-        std::cout << "Calibration Success. Values are: " 
-//            << " user0: " << user_values[0]
-//            << " user1: " << user_values[1]
-//            << " game0: " << game_values[0]
-//            << " game1: " << game_values[1]
-            << " a: " << a
-            << " b: " << b
-                  << std::endl;
-    };
-    virtual std::shared_ptr<Calibration> clone(){
-        return  std::make_shared<LinearCalibration>(a, b);
-    }
+        float a;
+        float b;
 };

--- a/source/core/event_translators/group/calibration.h
+++ b/source/core/event_translators/group/calibration.h
@@ -1,0 +1,116 @@
+#pragma once
+
+class Calibration{
+    public:
+        // Start calibration machine state 
+        virtual void start_calibration(bool reset_calibration) = 0;
+        // Save data for calibrate adn return true when calibration proccess finish
+        // If we need more data returns false
+        virtual bool save_calibrate_data(int64_t value) = 0;
+        // Aply the transformation from user_value to game value
+        virtual int64_t get_game_value(int64_t user_value) = 0;
+        virtual bool is_calibrating() = 0;
+        virtual std::shared_ptr<Calibration> clone() = 0;
+        virtual ~Calibration(){};
+};
+
+// Implements linear calibration: game_values = a * user_value + b
+// 
+class LinearCalibration : public Calibration {
+    typedef enum {
+        CALIBRATE_SLEEP,
+        CALIBRATE_WAITING_MY_INPUT_0,
+        CALIBRATE_WAITING_GAME_INPUT_0,
+        CALIBRATE_WAITING_MY_INPUT_1,
+        CALIBRATE_WAITING_GAME_INPUT_1,
+    }StatusCalibration;
+    public:
+    LinearCalibration(): a(1.0), b(0.0),status_calibration(CALIBRATE_SLEEP) {};
+    LinearCalibration(float a, float b): a(a), b(b), status_calibration(CALIBRATE_SLEEP){};
+    virtual ~LinearCalibration(){};
+    void start_calibration(bool reset_calibration) {
+        status_calibration = CALIBRATE_WAITING_MY_INPUT_0;
+        // reset the last calibration
+        if(reset_calibration){
+            a = 1.0;
+            b = 0.0;
+        }
+        std::cout << "Start Linear Calibration: " 
+            << (reset_calibration ? "reset": "composing with last calibration") << std::endl;
+    };
+    // Save data for calibrate and return true when calibration proccess finish
+    // If we need more data returns false
+    virtual bool save_calibrate_data(int64_t value){
+        switch(status_calibration){
+            case CALIBRATE_WAITING_MY_INPUT_0:
+                user_values[0] = get_game_value(value);
+                status_calibration = CALIBRATE_WAITING_GAME_INPUT_0;
+                break;
+            case CALIBRATE_WAITING_GAME_INPUT_0:
+                // now calibrate
+                game_values[0] = get_game_value(value);
+                status_calibration = CALIBRATE_WAITING_MY_INPUT_1;
+                break;
+            case CALIBRATE_WAITING_MY_INPUT_1:
+                user_values[1] = get_game_value(value);
+                //TODO save my_value;
+                status_calibration = CALIBRATE_WAITING_GAME_INPUT_1;
+                break;
+            case CALIBRATE_WAITING_GAME_INPUT_1:
+                // now calibrate
+                game_values[1] = get_game_value(value);
+                calibrate();
+                status_calibration = CALIBRATE_SLEEP;
+                return false;
+                break;
+            default:
+                std::cout << __PRETTY_FUNCTION__ 
+                    <<"ERROR: unspected state. Stopping calibration " << status_calibration 
+                    << std::endl;
+                status_calibration = CALIBRATE_SLEEP;
+        }
+        return true;
+    }
+    // Aply the transformation from user_value to game value
+    virtual int64_t get_game_value(int64_t user_value){
+        int64_t result = (user_value * a) + b;
+        // check saturation
+        if(result > ABS_RANGE){
+            result = ABS_RANGE;
+        }else if (result < -ABS_RANGE){
+            result = -ABS_RANGE;
+        }
+        return result;
+    }
+    virtual bool is_calibrating(){
+        return status_calibration != CALIBRATE_SLEEP;
+    }
+
+    protected:
+    float a;
+    float b;
+    int64_t game_values [2];
+    int64_t user_values [2];
+    StatusCalibration status_calibration;
+    void calibrate(){
+        // We have to resolve this system of ecuations
+        // game_values[0] = a * user_values[0] + b;
+        // game_values[1] = a * user_values[1] + b;
+        float tmp_a = ((float) (game_values[0] - game_values[1])) / ( (float) (user_values[0] -  user_values[1]));
+        float tmp_b = ((float) (user_values[0]*game_values[1] - game_values[0]*user_values[1])) / ((float)(user_values[0] - user_values[1]));
+        // Now we adjust to compose with last calibration.
+        a = tmp_a * a;
+        b = tmp_a*b + tmp_b;
+        std::cout << "Calibration Success. Values are: " 
+//            << " user0: " << user_values[0]
+//            << " user1: " << user_values[1]
+//            << " game0: " << game_values[0]
+//            << " game1: " << game_values[1]
+            << " a: " << a
+            << " b: " << b
+                  << std::endl;
+    };
+    virtual std::shared_ptr<Calibration> clone(){
+        return  std::make_shared<LinearCalibration>(a, b);
+    }
+};

--- a/source/core/event_translators/translators.h
+++ b/source/core/event_translators/translators.h
@@ -18,3 +18,7 @@
 #include "group/stick_dpad.h"
 
 #include "group/wiigyromouse.h"
+
+#include "group/calibratable.h"
+
+

--- a/source/core/parser.cpp
+++ b/source/core/parser.cpp
@@ -321,6 +321,7 @@ void MGparser::load_translators(moltengamepad* mg) {
   RENAME_GEN(exclusive,exclusive_chord);
   RENAME_GEN(stick,thumb_stick);
   RENAME_GEN(dpad,stick_dpad);
+  RENAME_GEN(calibratable,calibratable);
   MAKE_GEN(wiigyromouse);
 }
 


### PR DESCRIPTION


I have added a new feature that is online calibration. Yo can calibrate the gamepad while you are playing.  How to use and a review of the features is explained in a file that I added to [documentation](https://github.com/chanilino/MoltenGamepad/blob/online_calibration/documentation/calibratable.md).

I have implemented this like a new group that is _calibratable_. It needs a _key_ to start calibration process, an _axis_ to calibrate and other _key_ to say save this value to calibrate the data. It is implemented thinking in using **wiimote** like **light gun** in **MAME** or **nestopia**, and calibrate the gun while you are playing. And it works!!


I have implemented a linear calibration, but you can extend the abstract class calibration and implement other calibration models. All we have to do is to add parameters to the group saying which calibration model we want.