### PR TITLE
allow use of axis in chord group translator

### DIFF
--- a/source/core/devices/input_source.cpp
+++ b/source/core/devices/input_source.cpp
@@ -232,12 +232,11 @@ void input_source::update_group(const std::vector<std::string>& evnames, const s
   }
 
   //build the key to store this under.
-  auto its = local_names.begin();
-  std::string group_name = *its;
-  its++;
-  for (; its != local_names.end(); its++) {
-    group_name += "," + (*its);
+  std::string group_name;
+  for (int i = 0; i < local_names.size(); i++) {
+    group_name += local_names[i] + (((*msg.group.directions)[i] > 0)?"+":"-") + ",";
   }
+  group_name.pop_back();
   msg.group.key = new std::string(group_name);
 
   //Finally, instantiate the translator from it's prototype.

--- a/source/core/event_translators/group/simple_chord.cpp
+++ b/source/core/event_translators/group/simple_chord.cpp
@@ -13,6 +13,7 @@ bool simple_chord::set_mapped_events(const std::vector<source_event>& listened) 
     if ((ev.type != DEV_KEY) && (ev.type != DEV_AXIS))
       return false;
     event_vals.push_back(ev.value);
+    event_thres.push_back(ev.type == DEV_KEY?0:ABS_RANGE/2);
   }
   return true;
 }
@@ -37,7 +38,7 @@ simple_chord::~simple_chord() {
 
 bool simple_chord::claim_event(int id, mg_ev event) {
   bool output = true;
-  event_vals[id] = event.value > 0;
+  event_vals[id] = event.value > event_thres[id];
   for (int i = 0; i < event_vals.size(); i++) {
     output = output && (event_vals[i]);
   }

--- a/source/core/event_translators/group/simple_chord.cpp
+++ b/source/core/event_translators/group/simple_chord.cpp
@@ -10,7 +10,7 @@ simple_chord::simple_chord(std::vector<MGField>& fields) {
 bool simple_chord::set_mapped_events(const std::vector<source_event>& listened) {
   num_events = listened.size();
   for (auto ev : listened) {
-    if (ev.type != DEV_KEY)
+    if ((ev.type != DEV_KEY) && (ev.type != DEV_AXIS))
       return false;
     event_vals.push_back(ev.value);
   }
@@ -37,7 +37,7 @@ simple_chord::~simple_chord() {
 
 bool simple_chord::claim_event(int id, mg_ev event) {
   bool output = true;
-  event_vals[id] = event.value;
+  event_vals[id] = event.value > 0;
   for (int i = 0; i < event_vals.size(); i++) {
     output = output && (event_vals[i]);
   }

--- a/source/core/event_translators/group/simple_chord.h
+++ b/source/core/event_translators/group/simple_chord.h
@@ -4,6 +4,7 @@
 class simple_chord : public group_translator {
 public:
   std::vector<int> event_vals;
+  std::vector<int64_t> event_thres;
   int output_cache = 0;
   input_source* owner = nullptr;
   event_translator* out_trans = nullptr;

--- a/source/core/profile.cpp
+++ b/source/core/profile.cpp
@@ -216,17 +216,14 @@ void profile::set_group_mapping(std::vector<std::string> names, std::vector<int8
   //two purposes here: loop over all event names and 
   // 1) build up the key used to index this translator by concatenating the vent names
   // 2) verify that this profile actually has the event being named.
-  auto it = names.begin();
   //this key creation is not ideal.
-  std::string key = *it;
-  if (mapping.find(key) == mapping.end())
-    return; //abort! event not found.
-  it++;
-  for (; it != names.end(); it++) {
-    if (mapping.find(*it) == mapping.end())
+  std::string key;
+  for (int i = 0; i < names.size(); i++) {
+    if (mapping.find(names[i]) == mapping.end())
       return; //abort! event not found.
-    key += "," + (*it);
+    key += names[i] + ((directions[i] > 0)?"+":"-") + ",";
   }
+  key.pop_back();
 
   auto stored = group_trans.find(key);
   if (stored != group_trans.end()) {


### PR DESCRIPTION
I didn't find a way to translate a combination of button + axis, so I implemented it as part of the chord group translator

axis direction can be specified using + or -.

examples:

xpad.(start,leftright+) = chord(select)
xpad.(start,leftright) = chord(select). Same thing as above

xpad.(start,leftright-) = chord(mode)