### PR TITLE
Add support for Guitar extension in Wiimote plugin

### DIFF
--- a/source/plugin/wiimote/wii_default_profile.cpp
+++ b/source/plugin/wiimote/wii_default_profile.cpp
@@ -39,8 +39,10 @@ void wiimote_manager::init_profile() {
   methods.register_event_group(ref, {"wm_accels","wm_accel_x,wm_accel_y,wm_accel_z", "Wiimote Accelerometers", ""});
   methods.register_event_group(ref, {"nk_accels","nk_accel_x,nk_accel_y,nk_accel_z", "Nunchuk Accelerometers", ""});
   methods.register_event_group(ref, {"nk_wm_accels","nk_wm_accel_x,nk_wm_accel_y,nk_wm_accel_z", "Wiimote Accelerometers with Nunchuk", ""});
+  methods.register_event_group(ref, {"gt_accels","gt_accel_x,gt_accel_y,gt_accel_z", "Wiimote Accelerometers with Guitar", ""});
   methods.register_event_group(ref, {"wm_gyros","wm_gyro_x,wm_gyro_y,wm_gyro_z", "Wiimote Motion+ Gyroscopes", ""});
   methods.register_event_group(ref, {"nk_wm_gyros","nk_wm_gyro_x,nk_wm_gyro_y,nk_wm_gyro_z", "Wiimote Motion+ Gyroscopes with Nunchuk", ""});
+  methods.register_event_group(ref, {"gt_gyros","gt_gyro_x,gt_gyro_y,gt_gyro_z", "Wiimote Motion+ Gyroscopes with Guitar", ""});
 
   const option_decl* opt = &wiimote_options[0];
   for (int i = 0; opt->name && *opt->name; opt = &wiimote_options[++i]) {

--- a/source/plugin/wiimote/wii_events.cpp
+++ b/source/plugin/wiimote/wii_events.cpp
@@ -188,7 +188,7 @@ void wiimote::process_core() {
 };
 
 #define GUITAR_STICK_SCALE ABS_RANGE/24
-#define GUITAR_WHAMMY_SCALE ABS_RANGE/12
+#define GUITAR_WHAMMY_SCALE ABS_RANGE/6
 void wiimote::process_guitar(int fd) {
   struct input_event ev;
   int ret = read(fd, &ev, sizeof(ev));

--- a/source/plugin/wiimote/wii_events.cpp
+++ b/source/plugin/wiimote/wii_events.cpp
@@ -188,7 +188,7 @@ void wiimote::process_core() {
 };
 
 #define GUITAR_STICK_SCALE ABS_RANGE/24
-#define GUITAR_WHAMMY_SCALE ABS_RANGE
+#define GUITAR_WHAMMY_SCALE ABS_RANGE/12
 void wiimote::process_guitar(int fd) {
   struct input_event ev;
   int ret = read(fd, &ev, sizeof(ev));
@@ -225,13 +225,13 @@ void wiimote::process_guitar(int fd) {
       }
     else if (ev.type == EV_ABS) switch (ev.code) {
       case ABS_HAT1X:
-        send_value(gt_whammy, ev.value * GUITAR_WHAMMY_SCALE);
+        send_value(gt_whammy, (ev.value - 6) * GUITAR_WHAMMY_SCALE);
         break;
       case ABS_X:
         send_value(gt_stick_x, ev.value * GUITAR_STICK_SCALE);
         break;
       case ABS_Y:
-        send_value(gt_stick_y, -ev.value * GUITAR_STICK_SCALE);
+        send_value(gt_stick_y, ev.value * GUITAR_STICK_SCALE);
         break;
     }
     else {

--- a/source/plugin/wiimote/wii_events.h
+++ b/source/plugin/wiimote/wii_events.h
@@ -54,6 +54,20 @@ enum wii_keys {
   cc_right_x,
   cc_right_y,
 
+  gt_green,
+  gt_red,
+  gt_yellow,
+  gt_blue,
+  gt_orange,
+  gt_strumup,
+  gt_strumdown,
+  gt_plus,
+  gt_minus,
+
+  gt_stick_x,
+  gt_stick_y,
+  gt_whammy,
+
   wm_accel_x,
   wm_accel_y,
   wm_accel_z,
@@ -72,6 +86,10 @@ enum wii_keys {
   nk_stick_x,
   nk_stick_y,
 
+  gt_accel_x,
+  gt_accel_y,
+  gt_accel_z,
+
 
 
   bal_x,
@@ -83,6 +101,9 @@ enum wii_keys {
   nk_wm_gyro_x,
   nk_wm_gyro_y,
   nk_wm_gyro_z,
+  gt_gyro_x,
+  gt_gyro_y,
+  gt_gyro_z,
 
   wii_event_max
 };

--- a/source/plugin/wiimote/wiimote.h
+++ b/source/plugin/wiimote/wiimote.h
@@ -17,6 +17,7 @@
 #define MOTIONPLUS_NAME "Nintendo Wii Remote Motion Plus"
 #define NUNCHUK_NAME "Nintendo Wii Remote Nunchuk"
 #define CLASSIC_NAME "Nintendo Wii Remote Classic Controller"
+#define GUITAR_NAME "Nintendo Wii Remote Guitar"
 #define BALANCE_BOARD_NAME "Nintendo Wii Remote Balance Board"
 #define WII_U_PRO_NAME "Nintendo Wii Remote Pro Controller"
 
@@ -43,7 +44,7 @@ struct irdata {
   int y = 1023;
 };
 
-enum modes {NO_EXT, NUNCHUK_EXT, CLASSIC_EXT, PRO_EXT, BALANCE_EXT, MODE_UNCERTAIN};
+enum modes {NO_EXT, NUNCHUK_EXT, CLASSIC_EXT, GUITAR_EXT, PRO_EXT, BALANCE_EXT, MODE_UNCERTAIN};
 //MODE_UNCERTAIN is for the early stage where we don't know if this is a wiimote,
 // a balance board, or a Wii U Pro controller.
 
@@ -57,6 +58,7 @@ public:
   struct dev_node motionplus;
   struct dev_node nunchuk;
   struct dev_node classic;
+  struct dev_node guitar;
   struct dev_node pro;
   struct dev_node balance;
   struct wii_leds leds;
@@ -108,10 +110,12 @@ private:
   std::mutex mode_lock;
   bool wm_accel_active = false;
   bool nk_accel_active = false;
+  bool gt_accel_active = false;
   bool wm_ir_active = false;
   bool nk_ir_active = false;
   bool wm_gyro_active = false;
   bool nk_gyro_active = false;
+  bool gt_gyro_active = false;
   bool grab_exclusive = true;
   bool grab_permissions = false;
 
@@ -132,6 +136,7 @@ private:
   };
   void process_core();
   void process_classic(int fd);
+  void process_guitar(int fd);
   void process_nunchuk(int fd);
   void process_accel(int fd);
   void process_ir(int fd);


### PR DESCRIPTION
Hi :)
I wanted to use the accelerometer / gyrometer in combination with my Wiimote guitar so I patched your (awesome) tool and added Wiimote guitar support.

Originally I just wanted to hack it in for personal use, but the changes were pretty simple and clean enough that I might as well share it with the world.

Please take a look at my pull request. Feel free to critique everything you don't like. Please also tell me if and where I should add more documentation about my changes.

I have tested my changes with the original Guitar that came with Guitar Hero 3 and everything seems to be working correctly. Attached you can find an example config that I used for testing.

[clonehero.txt](https://github.com/jgeumlek/MoltenGamepad/files/4051722/clonehero.txt)

