### PR TITLE
Update /var/run/ -> /run/

### DIFF
--- a/installation/systemuser/systemd.service
+++ b/installation/systemuser/systemd.service
@@ -7,11 +7,11 @@ Description=MoltenGamepad Event Translator
 User=gamepad
 Group=gamepad
 Type=forking
-PIDFile=/var/run/moltengamepad/pid
+PIDFile=/run/moltengamepad/pid
 ExecStart=/usr/local/bin/moltengamepad \
- --daemon --pidfile /var/run/moltengamepad/pid \
- --replace-fifo --fifo-path /var/run/moltengamepad/fifo \
- --make-socket --socket-path /var/run/moltengamepad/socket
+ --daemon --pidfile /run/moltengamepad/pid \
+ --replace-fifo --fifo-path /run/moltengamepad/fifo \
+ --make-socket --socket-path /run/moltengamepad/socket
 ExecStop=/usr/bin/kill $MAINPID
 StandardOutput=journal+console
 StandardError=journal+console

--- a/installation/systemuser/tmpfiles.conf
+++ b/installation/systemuser/tmpfiles.conf
@@ -1,2 +1,2 @@
 # Installs as /etc/tmpfiles.d/moltengamepad.conf
-D /var/run/moltengamepad 0755 gamepad gamepad
+D /run/moltengamepad 0755 gamepad gamepad


### PR DESCRIPTION
Starting with systemd 239, using /var/run is deprecated. /run should be
used instead. See https://github.com/systemd/systemd/commit/a2d1fb882c4308bc10362d971f333c5031d60069