### PR TITLE
fix exception trying to instantiated std::string with null

### DIFF
--- a/source/core/udev.cpp
+++ b/source/core/udev.cpp
@@ -245,7 +245,9 @@ int udev_handler::grab_permissions(udev_device* dev, bool grabbed, int flags) {
     //go up a level to find siblings...
     std::string devpath(udev_device_get_syspath(dev));
     std::string parentpath(udev_device_get_syspath(parent));
-    std::string hidparentpath(udev_device_get_syspath(hid_parent));
+    std::string hidparentpath(parentpath);
+    hidparentpath += "/../..";
+    if (hid_parent) hidparentpath = udev_device_get_syspath(hid_parent);
     std::string globstr = "";
     if (!subsystem)
       return SUCCESS; //we grabbed all that we know how to do!


### PR DESCRIPTION
when plugging in a controller that has no parent of type usbhid.
This happens when I plug in my original XBox 360 controller on
Kernel 5.4.72 (handled by xpad driver)